### PR TITLE
计算时间有错误

### DIFF
--- a/dcgan_torch_gpu.ipynb
+++ b/dcgan_torch_gpu.ipynb
@@ -212,7 +212,7 @@
     "            save_image(fake, path, normalize=False)\n",
     "            \n",
     "end = time.time()\n",
-    "print((end - time_open)/60) #输出结束时间(单位：分钟)"
+    "print((end - start)/60) #输出结束时间(单位：分钟)"
    ]
   },
   {


### PR DESCRIPTION
在倒数第二cell（即是用来训练的cell之中），计算时间的代码有错误
time_open并不是作为以命名变量的存在，
`print((end - time_open)/60)`
应该变为
`print((end - start)/60)`